### PR TITLE
Add rule for OC legacy getters

### DIFF
--- a/src/Rector/LegacyGetterToOcpServerGetRector.php
+++ b/src/Rector/LegacyGetterToOcpServerGetRector.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Nextcloud\Rector\Rector;
 
+use InvalidArgumentException;
 use Nextcloud\Rector\ValueObject\LegacyGetterToOcpServerGet;
 use PHPStan\Type\ObjectType;
 use PhpParser\Node;
@@ -16,7 +17,6 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticPropertyFetch;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
-use RectorPrefix202409\Webmozart\Assert\Assert;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -51,11 +51,11 @@ CODE_SAMPLE
         return [MethodCall::class];
     }
 
-    /**
-     * @param MethodCall $node
-     */
     public function refactor(Node $node): ?Node
     {
+        if (!($node instanceof MethodCall)) {
+            return null;
+        }
         foreach ($this->legacyGetterToOcpServerGet as $config) {
             if (!$node->var instanceof StaticPropertyFetch) {
                 continue;
@@ -85,7 +85,15 @@ CODE_SAMPLE
      */
     public function configure(array $configuration): void
     {
-        Assert::allIsAOf($configuration, LegacyGetterToOcpServerGet::class);
+        foreach ($configuration as $config) {
+            if (!$config instanceof LegacyGetterToOcpServerGet) {
+                throw new InvalidArgumentException('Only supports LegacyGetterToOcpServerGet configurations');
+            }
+        }
+        /**
+         * @psalm-suppress MixedPropertyTypeCoercion
+         * @phpstan-ignore assign.propertyType
+         */
         $this->legacyGetterToOcpServerGet = $configuration;
     }
 }

--- a/src/Rector/LegacyGetterToOcpServerGetRector.php
+++ b/src/Rector/LegacyGetterToOcpServerGetRector.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace Nextcloud\Rector\Rector;
+
+use Nextcloud\Rector\ValueObject\LegacyGetterToOcpServerGet;
+use PHPStan\Type\ObjectType;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Rector\AbstractRector;
+use RectorPrefix202409\Webmozart\Assert\Assert;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class LegacyGetterToOcpServerGetRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var LegacyGetterToOcpServerGet[]
+     */
+    private array $legacyGetterToOcpServerGet = [];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace legacy getter calls on \OC::$server to desired static call on \OCP\Server',
+            [
+                new ConfiguredCodeSample(<<<'CODE_SAMPLE'
+\OC::$server->getLogger()->debug('debug log');
+CODE_SAMPLE
+            , <<<'CODE_SAMPLE'
+\OCP::Server::get(\Psr\Log\LoggerInterface::class)->debug('debug log');
+CODE_SAMPLE
+            , [new LegacyGetterToOcpServerGet('getLogger', '\Psr\Log\LoggerInterface')]),
+            ],
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        foreach ($this->legacyGetterToOcpServerGet as $config) {
+            if (!$node->var instanceof StaticPropertyFetch) {
+                continue;
+            }
+            if (!$this->isName($node->var->name, 'server')) {
+                continue;
+            }
+            if (!$this->isName($node->name, $config->getOldMethod())) {
+                continue;
+            }
+            if (!$this->isObjectType($node->var->class, new ObjectType('OC'))) {
+                continue;
+            }
+
+            return $this->nodeFactory->createStaticCall(
+                'OCP\Server',
+                'get',
+                [$this->nodeFactory->createClassConstReference($config->getNewClass())],
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, LegacyGetterToOcpServerGet::class);
+        $this->legacyGetterToOcpServerGet = $configuration;
+    }
+}

--- a/src/ValueObject/LegacyGetterToOcpServerGet.php
+++ b/src/ValueObject/LegacyGetterToOcpServerGet.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace Nextcloud\Rector\ValueObject;
+
+use Rector\Validation\RectorAssert;
+
+final class LegacyGetterToOcpServerGet
+{
+    public function __construct(
+        private string $oldMethod,
+        private string $newClass,
+    ) {
+        RectorAssert::className($oldMethod);
+        RectorAssert::className($newClass);
+    }
+
+    public function getOldMethod(): string
+    {
+        return $this->oldMethod;
+    }
+
+    public function getNewClass(): string
+    {
+        return $this->newClass;
+    }
+}

--- a/tests/Rector/LegacyGetterToOcpServerGetRector/Fixture/test_fixture.php.inc
+++ b/tests/Rector/LegacyGetterToOcpServerGetRector/Fixture/test_fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Nextcloud\Rector\Test\Rector\OcServerToOcpServerRector\Fixture;
+
+use OC;
+
+class SomeClass
+{
+    public function foo()
+    {
+        $request1 = OC::$server->getRequest();
+        $request2 = \OC::$server->getRequest();
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Nextcloud\Rector\Test\Rector\OcServerToOcpServerRector\Fixture;
+
+use OC;
+
+class SomeClass
+{
+    public function foo()
+    {
+        $request1 = \OCP\Server::get(\OCP\IRequest::class);
+        $request2 = \OCP\Server::get(\OCP\IRequest::class);
+    }
+}
+
+?>

--- a/tests/Rector/LegacyGetterToOcpServerGetRector/LegacyGetterToOcpServerGetRectorTest.php
+++ b/tests/Rector/LegacyGetterToOcpServerGetRector/LegacyGetterToOcpServerGetRectorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Nextcloud\Rector\Test\Rector\LegacyGetterToOcpServerGetRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class LegacyGetterToOcpServerGetRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config.php';
+    }
+}

--- a/tests/Rector/LegacyGetterToOcpServerGetRector/config/config.php
+++ b/tests/Rector/LegacyGetterToOcpServerGetRector/config/config.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Nextcloud\Rector\Rector\LegacyGetterToOcpServerGetRector;
+use Nextcloud\Rector\ValueObject\LegacyGetterToOcpServerGet;
+use OCP\IRequest;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withConfiguredRule(
+        LegacyGetterToOcpServerGetRector::class,
+        [
+            new LegacyGetterToOcpServerGet('getRequest', IRequest::class),
+        ],
+    );

--- a/tests/Rector/LegacyGetterToOcpServerGetRector/config/config.php
+++ b/tests/Rector/LegacyGetterToOcpServerGetRector/config/config.php
@@ -11,6 +11,7 @@ return RectorConfig::configure()
     ->withConfiguredRule(
         LegacyGetterToOcpServerGetRector::class,
         [
+            /** @phpstan-ignore class.notFound */
             new LegacyGetterToOcpServerGet('getRequest', IRequest::class),
         ],
     );


### PR DESCRIPTION
Turn legacy getters into OCP\Server::get