### PR TITLE
Add legacy getter rector to set

### DIFF
--- a/config/nextcloud-25/nextcloud-25-deprecations.php
+++ b/config/nextcloud-25/nextcloud-25-deprecations.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Nextcloud\Rector\Rector\LegacyGetterToOcpServerGetRector;
 use Nextcloud\Rector\Rector\OcServerToOcpServerRector;
 use Rector\Config\RectorConfig;
 
@@ -9,4 +10,188 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rules([
         OcServerToOcpServerRector::class,
     ]);
+    $rectorConfig->ruleWithConfiguration(
+        LegacyGetterToOcpServerGetRector::class,
+        [
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getCalendarManager', '\OCP\Calendar\IManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getCalendarResourceBackendManager', '\OCP\Calendar\Resource\IManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getCalendarRoomBackendManager', '\OCP\Calendar\Room\IManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getContactsManager', '\OCP\Contacts\IManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getEncryptionManager', '\OCP\Encryption\IManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getEncryptionFilesHelper', '\OCP\Encryption\IFile'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getEncryptionKeyStorage', '\OCP\Encryption\Keys\IStorage'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getRequest', '\OCP\IRequest'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getPreviewManager', '\OCP\IPreview'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getTagManager', '\OCP\ITagManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getSystemTagManager', '\OCP\SystemTag\ISystemTagManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getSystemTagObjectMapper', '\OCP\SystemTag\ISystemTagObjectMapper'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getAvatarManager', '\OCP\IAvatarManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getRootFolder', '\OCP\Files\IRootFolder'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getLazyRootFolder', '\OCP\Files\IRootFolder'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getUserManager', '\OCP\User\IManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getGroupManager', '\OCP\Group\IManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getUserSession', '\OCP\IUserSession'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getSession', '\OCP\ISession'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getTwoFactorAuthManager', '\OC\Authentication\TwoFactorAuth\Manager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getNavigationManager', '\OCP\INavigationManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getConfig', '\OCP\IConfig'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getSystemConfig', '\OC\SystemConfig'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getAppConfig', '\OCP\IAppConfig'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getURLGenerator', '\OCP\IURLGenerator'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getAppFetcher', '\OC\App\AppStore\Fetcher\AppFetcher'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getMemCacheFactory', '\OCP\ICacheFactory'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getGetRedisFactory', '\OC\RedisFactory'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getDatabaseConnection', '\OCP\IDBConnection'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getActivityManager', '\OCP\Activity\IManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getJobList', '\OCP\BackgroundJob\IJobList'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getLogFactory', '\OCP\Log\ILogFactory'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getRouter', '\OCP\Route\IRouter'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getSecureRandom', '\OCP\Security\ISecureRandom'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getCrypto', '\OCP\Security\ICrypto'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getHasher', '\OCP\Security\IHasher'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getCredentialsManager', '\OCP\Security\ICredentialsManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getHTTPClientService', '\OCP\Http\Client\IClientService'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getEventLogger', '\OCP\Diagnostics\IEventLogger'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getQueryLogger', '\OCP\Diagnostics\IQueryLogger'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getTempManager', '\OCP\ITempManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getAppManager', '\OCP\App\IAppManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getMailer', '\OCP\Mail\IMailer'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getDateTimeZone', '\OCP\IDateTimeZone'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getDateTimeFormatter', '\OCP\IDateTimeFormatter'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getMountProviderCollection', '\OCP\Files\Config\IMountProviderCollection'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getIniWrapper', '\bantu\IniGetWrapper\IniGetWrapper'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getCommandBus', '\OCP\Command\IBus'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getTrustedDomainHelper', '\OCP\Security\ITrustedDomainHelper'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getLockingProvider', '\OCP\Lock\ILockingProvider'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getMountManager', '\OCP\Files\Mount\IMountManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getUserMountCache', '\OCP\Files\Config\IUserMountCache'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getMimeTypeDetector', '\OCP\Files\IMimeTypeDetector'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getMimeTypeLoader', '\OCP\Files\IMimeTypeLoader'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getNotificationManager', '\OCP\Notification\IManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getCommentsManager', '\OCP\Comments\ICommentsManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getThemingDefaults', '\OCA\Theming\ThemingDefaults'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getIntegrityCodeChecker', '\OC\IntegrityCheck\Checker'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getSessionCryptoWrapper', '\OC\Session\CryptoWrapper'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getCsrfTokenManager', '\OC\Security\CSRF\CsrfTokenManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getBruteForceThrottler', '\OCP\Security\Bruteforce\IThrottler'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet(
+                'getContentSecurityPolicyManager',
+                'OCP\Security\IContentSecurityPolicyManager',
+            ),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet(
+                'getContentSecurityPolicyNonceManager',
+                'OC\Security\CSP\ContentSecurityPolicyNonceManager',
+            ),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getStoragesBackendService', '\OCA\Files_External\Service\BackendService'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet(
+                'getGlobalStoragesService',
+                'OCA\Files_External\Service\GlobalStoragesService',
+            ),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet(
+                'getUserGlobalStoragesService',
+                'OCA\Files_External\Service\UserGlobalStoragesService',
+            ),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getUserStoragesService', '\OCA\Files_External\Service\UserStoragesService'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getShareManager', '\OCP\Share\IManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getCollaboratorSearch', '\OCP\Collaboration\Collaborators\ISearch'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getAutoCompleteManager', '\OCP\Collaboration\AutoComplete\IManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getLDAPProvider', '\OCP\LDAP\ILDAPProvider'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getSettingsManager', '\OCP\Settings\IManager'),
+            // Deprecated since 20.0.0 Use 'get(\OCP\Files\AppData\IAppDataFactory')->get($app) instead
+            new LegacyGetterToOcpServerGet('getAppDataDir', '\OCP\Files\IAppData'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getLockdownManager', '\OCP\Lockdown\ILockdownManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getCloudIdManager', '\OCP\Federation\ICloudIdManager'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getGlobalScaleConfig', '\OCP\GlobalScale\IConfig'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet(
+                'getCloudFederationProviderManager',
+                'OCP\Federation\ICloudFederationProviderManager',
+            ),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getRemoteApiFactory', '\OCP\Remote\Api\IApiFactory'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getCloudFederationFactory', '\OCP\Federation\ICloudFederationFactory'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getRemoteInstanceFactory', '\OCP\Remote\IInstanceFactory'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getStorageFactory', '\OCP\Files\Storage\IStorageFactory'),
+            // Deprecated since 20.0.0
+            new LegacyGetterToOcpServerGet('getGeneratorHelper', '\OC\Preview\GeneratorHelper'),
+        ],
+    );
 };

--- a/config/nextcloud-25/nextcloud-25-deprecations.php
+++ b/config/nextcloud-25/nextcloud-25-deprecations.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Nextcloud\Rector\Rector\LegacyGetterToOcpServerGetRector;
 use Nextcloud\Rector\Rector\OcServerToOcpServerRector;
+use Nextcloud\Rector\ValueObject\LegacyGetterToOcpServerGet;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -14,127 +15,127 @@ return static function (RectorConfig $rectorConfig): void {
         LegacyGetterToOcpServerGetRector::class,
         [
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getCalendarManager', '\OCP\Calendar\IManager'),
+            new LegacyGetterToOcpServerGet('getCalendarManager', 'OCP\Calendar\IManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getCalendarResourceBackendManager', '\OCP\Calendar\Resource\IManager'),
+            new LegacyGetterToOcpServerGet('getCalendarResourceBackendManager', 'OCP\Calendar\Resource\IManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getCalendarRoomBackendManager', '\OCP\Calendar\Room\IManager'),
+            new LegacyGetterToOcpServerGet('getCalendarRoomBackendManager', 'OCP\Calendar\Room\IManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getContactsManager', '\OCP\Contacts\IManager'),
+            new LegacyGetterToOcpServerGet('getContactsManager', 'OCP\Contacts\IManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getEncryptionManager', '\OCP\Encryption\IManager'),
+            new LegacyGetterToOcpServerGet('getEncryptionManager', 'OCP\Encryption\IManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getEncryptionFilesHelper', '\OCP\Encryption\IFile'),
+            new LegacyGetterToOcpServerGet('getEncryptionFilesHelper', 'OCP\Encryption\IFile'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getEncryptionKeyStorage', '\OCP\Encryption\Keys\IStorage'),
+            new LegacyGetterToOcpServerGet('getEncryptionKeyStorage', 'OCP\Encryption\Keys\IStorage'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getRequest', '\OCP\IRequest'),
+            new LegacyGetterToOcpServerGet('getRequest', 'OCP\IRequest'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getPreviewManager', '\OCP\IPreview'),
+            new LegacyGetterToOcpServerGet('getPreviewManager', 'OCP\IPreview'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getTagManager', '\OCP\ITagManager'),
+            new LegacyGetterToOcpServerGet('getTagManager', 'OCP\ITagManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getSystemTagManager', '\OCP\SystemTag\ISystemTagManager'),
+            new LegacyGetterToOcpServerGet('getSystemTagManager', 'OCP\SystemTag\ISystemTagManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getSystemTagObjectMapper', '\OCP\SystemTag\ISystemTagObjectMapper'),
+            new LegacyGetterToOcpServerGet('getSystemTagObjectMapper', 'OCP\SystemTag\ISystemTagObjectMapper'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getAvatarManager', '\OCP\IAvatarManager'),
+            new LegacyGetterToOcpServerGet('getAvatarManager', 'OCP\IAvatarManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getRootFolder', '\OCP\Files\IRootFolder'),
+            new LegacyGetterToOcpServerGet('getRootFolder', 'OCP\Files\IRootFolder'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getLazyRootFolder', '\OCP\Files\IRootFolder'),
+            new LegacyGetterToOcpServerGet('getLazyRootFolder', 'OCP\Files\IRootFolder'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getUserManager', '\OCP\User\IManager'),
+            new LegacyGetterToOcpServerGet('getUserManager', 'OCP\User\IManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getGroupManager', '\OCP\Group\IManager'),
+            new LegacyGetterToOcpServerGet('getGroupManager', 'OCP\Group\IManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getUserSession', '\OCP\IUserSession'),
+            new LegacyGetterToOcpServerGet('getUserSession', 'OCP\IUserSession'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getSession', '\OCP\ISession'),
+            new LegacyGetterToOcpServerGet('getSession', 'OCP\ISession'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getTwoFactorAuthManager', '\OC\Authentication\TwoFactorAuth\Manager'),
+            new LegacyGetterToOcpServerGet('getTwoFactorAuthManager', 'OC\Authentication\TwoFactorAuth\Manager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getNavigationManager', '\OCP\INavigationManager'),
+            new LegacyGetterToOcpServerGet('getNavigationManager', 'OCP\INavigationManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getConfig', '\OCP\IConfig'),
+            new LegacyGetterToOcpServerGet('getConfig', 'OCP\IConfig'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getSystemConfig', '\OC\SystemConfig'),
+            new LegacyGetterToOcpServerGet('getSystemConfig', 'OC\SystemConfig'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getAppConfig', '\OCP\IAppConfig'),
+            new LegacyGetterToOcpServerGet('getAppConfig', 'OCP\IAppConfig'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getURLGenerator', '\OCP\IURLGenerator'),
+            new LegacyGetterToOcpServerGet('getURLGenerator', 'OCP\IURLGenerator'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getAppFetcher', '\OC\App\AppStore\Fetcher\AppFetcher'),
+            new LegacyGetterToOcpServerGet('getAppFetcher', 'OC\App\AppStore\Fetcher\AppFetcher'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getMemCacheFactory', '\OCP\ICacheFactory'),
+            new LegacyGetterToOcpServerGet('getMemCacheFactory', 'OCP\ICacheFactory'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getGetRedisFactory', '\OC\RedisFactory'),
+            new LegacyGetterToOcpServerGet('getGetRedisFactory', 'OC\RedisFactory'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getDatabaseConnection', '\OCP\IDBConnection'),
+            new LegacyGetterToOcpServerGet('getDatabaseConnection', 'OCP\IDBConnection'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getActivityManager', '\OCP\Activity\IManager'),
+            new LegacyGetterToOcpServerGet('getActivityManager', 'OCP\Activity\IManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getJobList', '\OCP\BackgroundJob\IJobList'),
+            new LegacyGetterToOcpServerGet('getJobList', 'OCP\BackgroundJob\IJobList'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getLogFactory', '\OCP\Log\ILogFactory'),
+            new LegacyGetterToOcpServerGet('getLogFactory', 'OCP\Log\ILogFactory'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getRouter', '\OCP\Route\IRouter'),
+            new LegacyGetterToOcpServerGet('getRouter', 'OCP\Route\IRouter'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getSecureRandom', '\OCP\Security\ISecureRandom'),
+            new LegacyGetterToOcpServerGet('getSecureRandom', 'OCP\Security\ISecureRandom'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getCrypto', '\OCP\Security\ICrypto'),
+            new LegacyGetterToOcpServerGet('getCrypto', 'OCP\Security\ICrypto'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getHasher', '\OCP\Security\IHasher'),
+            new LegacyGetterToOcpServerGet('getHasher', 'OCP\Security\IHasher'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getCredentialsManager', '\OCP\Security\ICredentialsManager'),
+            new LegacyGetterToOcpServerGet('getCredentialsManager', 'OCP\Security\ICredentialsManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getHTTPClientService', '\OCP\Http\Client\IClientService'),
+            new LegacyGetterToOcpServerGet('getHTTPClientService', 'OCP\Http\Client\IClientService'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getEventLogger', '\OCP\Diagnostics\IEventLogger'),
+            new LegacyGetterToOcpServerGet('getEventLogger', 'OCP\Diagnostics\IEventLogger'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getQueryLogger', '\OCP\Diagnostics\IQueryLogger'),
+            new LegacyGetterToOcpServerGet('getQueryLogger', 'OCP\Diagnostics\IQueryLogger'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getTempManager', '\OCP\ITempManager'),
+            new LegacyGetterToOcpServerGet('getTempManager', 'OCP\ITempManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getAppManager', '\OCP\App\IAppManager'),
+            new LegacyGetterToOcpServerGet('getAppManager', 'OCP\App\IAppManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getMailer', '\OCP\Mail\IMailer'),
+            new LegacyGetterToOcpServerGet('getMailer', 'OCP\Mail\IMailer'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getDateTimeZone', '\OCP\IDateTimeZone'),
+            new LegacyGetterToOcpServerGet('getDateTimeZone', 'OCP\IDateTimeZone'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getDateTimeFormatter', '\OCP\IDateTimeFormatter'),
+            new LegacyGetterToOcpServerGet('getDateTimeFormatter', 'OCP\IDateTimeFormatter'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getMountProviderCollection', '\OCP\Files\Config\IMountProviderCollection'),
+            new LegacyGetterToOcpServerGet('getMountProviderCollection', 'OCP\Files\Config\IMountProviderCollection'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getIniWrapper', '\bantu\IniGetWrapper\IniGetWrapper'),
+            new LegacyGetterToOcpServerGet('getIniWrapper', 'bantu\IniGetWrapper\IniGetWrapper'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getCommandBus', '\OCP\Command\IBus'),
+            new LegacyGetterToOcpServerGet('getCommandBus', 'OCP\Command\IBus'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getTrustedDomainHelper', '\OCP\Security\ITrustedDomainHelper'),
+            new LegacyGetterToOcpServerGet('getTrustedDomainHelper', 'OCP\Security\ITrustedDomainHelper'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getLockingProvider', '\OCP\Lock\ILockingProvider'),
+            new LegacyGetterToOcpServerGet('getLockingProvider', 'OCP\Lock\ILockingProvider'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getMountManager', '\OCP\Files\Mount\IMountManager'),
+            new LegacyGetterToOcpServerGet('getMountManager', 'OCP\Files\Mount\IMountManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getUserMountCache', '\OCP\Files\Config\IUserMountCache'),
+            new LegacyGetterToOcpServerGet('getUserMountCache', 'OCP\Files\Config\IUserMountCache'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getMimeTypeDetector', '\OCP\Files\IMimeTypeDetector'),
+            new LegacyGetterToOcpServerGet('getMimeTypeDetector', 'OCP\Files\IMimeTypeDetector'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getMimeTypeLoader', '\OCP\Files\IMimeTypeLoader'),
+            new LegacyGetterToOcpServerGet('getMimeTypeLoader', 'OCP\Files\IMimeTypeLoader'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getNotificationManager', '\OCP\Notification\IManager'),
+            new LegacyGetterToOcpServerGet('getNotificationManager', 'OCP\Notification\IManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getCommentsManager', '\OCP\Comments\ICommentsManager'),
+            new LegacyGetterToOcpServerGet('getCommentsManager', 'OCP\Comments\ICommentsManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getThemingDefaults', '\OCA\Theming\ThemingDefaults'),
+            new LegacyGetterToOcpServerGet('getThemingDefaults', 'OCA\Theming\ThemingDefaults'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getIntegrityCodeChecker', '\OC\IntegrityCheck\Checker'),
+            new LegacyGetterToOcpServerGet('getIntegrityCodeChecker', 'OC\IntegrityCheck\Checker'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getSessionCryptoWrapper', '\OC\Session\CryptoWrapper'),
+            new LegacyGetterToOcpServerGet('getSessionCryptoWrapper', 'OC\Session\CryptoWrapper'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getCsrfTokenManager', '\OC\Security\CSRF\CsrfTokenManager'),
+            new LegacyGetterToOcpServerGet('getCsrfTokenManager', 'OC\Security\CSRF\CsrfTokenManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getBruteForceThrottler', '\OCP\Security\Bruteforce\IThrottler'),
+            new LegacyGetterToOcpServerGet('getBruteForceThrottler', 'OCP\Security\Bruteforce\IThrottler'),
             // Deprecated since 20.0.0
             new LegacyGetterToOcpServerGet(
                 'getContentSecurityPolicyManager',
@@ -146,7 +147,7 @@ return static function (RectorConfig $rectorConfig): void {
                 'OC\Security\CSP\ContentSecurityPolicyNonceManager',
             ),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getStoragesBackendService', '\OCA\Files_External\Service\BackendService'),
+            new LegacyGetterToOcpServerGet('getStoragesBackendService', 'OCA\Files_External\Service\BackendService'),
             // Deprecated since 20.0.0
             new LegacyGetterToOcpServerGet(
                 'getGlobalStoragesService',
@@ -158,40 +159,40 @@ return static function (RectorConfig $rectorConfig): void {
                 'OCA\Files_External\Service\UserGlobalStoragesService',
             ),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getUserStoragesService', '\OCA\Files_External\Service\UserStoragesService'),
+            new LegacyGetterToOcpServerGet('getUserStoragesService', 'OCA\Files_External\Service\UserStoragesService'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getShareManager', '\OCP\Share\IManager'),
+            new LegacyGetterToOcpServerGet('getShareManager', 'OCP\Share\IManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getCollaboratorSearch', '\OCP\Collaboration\Collaborators\ISearch'),
+            new LegacyGetterToOcpServerGet('getCollaboratorSearch', 'OCP\Collaboration\Collaborators\ISearch'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getAutoCompleteManager', '\OCP\Collaboration\AutoComplete\IManager'),
+            new LegacyGetterToOcpServerGet('getAutoCompleteManager', 'OCP\Collaboration\AutoComplete\IManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getLDAPProvider', '\OCP\LDAP\ILDAPProvider'),
+            new LegacyGetterToOcpServerGet('getLDAPProvider', 'OCP\LDAP\ILDAPProvider'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getSettingsManager', '\OCP\Settings\IManager'),
+            new LegacyGetterToOcpServerGet('getSettingsManager', 'OCP\Settings\IManager'),
             // Deprecated since 20.0.0 Use 'get(\OCP\Files\AppData\IAppDataFactory')->get($app) instead
-            new LegacyGetterToOcpServerGet('getAppDataDir', '\OCP\Files\IAppData'),
+            new LegacyGetterToOcpServerGet('getAppDataDir', 'OCP\Files\IAppData'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getLockdownManager', '\OCP\Lockdown\ILockdownManager'),
+            new LegacyGetterToOcpServerGet('getLockdownManager', 'OCP\Lockdown\ILockdownManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getCloudIdManager', '\OCP\Federation\ICloudIdManager'),
+            new LegacyGetterToOcpServerGet('getCloudIdManager', 'OCP\Federation\ICloudIdManager'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getGlobalScaleConfig', '\OCP\GlobalScale\IConfig'),
+            new LegacyGetterToOcpServerGet('getGlobalScaleConfig', 'OCP\GlobalScale\IConfig'),
             // Deprecated since 20.0.0
             new LegacyGetterToOcpServerGet(
                 'getCloudFederationProviderManager',
                 'OCP\Federation\ICloudFederationProviderManager',
             ),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getRemoteApiFactory', '\OCP\Remote\Api\IApiFactory'),
+            new LegacyGetterToOcpServerGet('getRemoteApiFactory', 'OCP\Remote\Api\IApiFactory'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getCloudFederationFactory', '\OCP\Federation\ICloudFederationFactory'),
+            new LegacyGetterToOcpServerGet('getCloudFederationFactory', 'OCP\Federation\ICloudFederationFactory'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getRemoteInstanceFactory', '\OCP\Remote\IInstanceFactory'),
+            new LegacyGetterToOcpServerGet('getRemoteInstanceFactory', 'OCP\Remote\IInstanceFactory'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getStorageFactory', '\OCP\Files\Storage\IStorageFactory'),
+            new LegacyGetterToOcpServerGet('getStorageFactory', 'OCP\Files\Storage\IStorageFactory'),
             // Deprecated since 20.0.0
-            new LegacyGetterToOcpServerGet('getGeneratorHelper', '\OC\Preview\GeneratorHelper'),
+            new LegacyGetterToOcpServerGet('getGeneratorHelper', 'OC\Preview\GeneratorHelper'),
         ],
     );
 };

--- a/tests/Rector/LegacyGetterToOcpServerGetRector/Fixture/test_fixture.php.inc
+++ b/tests/Rector/LegacyGetterToOcpServerGetRector/Fixture/test_fixture.php.inc
@@ -10,6 +10,7 @@ class SomeClass
     {
         $request1 = OC::$server->getRequest();
         $request2 = \OC::$server->getRequest();
+        $contactManager = \OC::$server->getContactsManager();
     }
 }
 
@@ -27,6 +28,7 @@ class SomeClass
     {
         $request1 = \OCP\Server::get(\OCP\IRequest::class);
         $request2 = \OCP\Server::get(\OCP\IRequest::class);
+        $contactManager = \OCP\Server::get(\OCP\Contacts\IManager::class);
     }
 }
 

--- a/tests/Rector/LegacyGetterToOcpServerGetRector/config/config.php
+++ b/tests/Rector/LegacyGetterToOcpServerGetRector/config/config.php
@@ -13,5 +13,6 @@ return RectorConfig::configure()
         [
             /** @phpstan-ignore class.notFound */
             new LegacyGetterToOcpServerGet('getRequest', IRequest::class),
+            new LegacyGetterToOcpServerGet('getContactsManager', 'OCP\Contacts\IManager'),
         ],
     );

--- a/tests/Set/Fixture/test_fixture.php.inc
+++ b/tests/Set/Fixture/test_fixture.php.inc
@@ -13,6 +13,9 @@ class SomeClass
         $request2 = \OC::$server->get('\OCP\IRequest');
         $request3 = OC::$server->get(IRequest::class);
         script('mail', 'mail');
+        $request4 = OC::$server->getRequest();
+        $request5 = \OC::$server->getRequest();
+        $contactManager = \OC::$server->getContactsManager();
     }
 }
 
@@ -33,6 +36,9 @@ class SomeClass
         $request2 = \OCP\Server::get('\OCP\IRequest');
         $request3 = \OCP\Server::get(IRequest::class);
         \OCP\Util::addScript('mail', 'mail', 'core');
+        $request4 = \OCP\Server::get(\OCP\IRequest::class);
+        $request5 = \OCP\Server::get(\OCP\IRequest::class);
+        $contactManager = \OCP\Server::get(\OCP\Contacts\IManager::class);
     }
 }
 


### PR DESCRIPTION
I generated that from lib/private/Server.php

I removed some which failed:

 * getLogger
 * getWebRoot
 * getL10N
 * getL10NFactory
 * getCapabilitiesManager
 * getCache

I don’t know about the ones which are from OC namespace, should we really expose them? They should only be used in server.

I had to use strings and not class names because otherwise the evil pre-commit hook wanted me to import all the classes.