### PR TITLE
fix: dont use assert for now

### DIFF
--- a/src/Rector/RenameParameterRector.php
+++ b/src/Rector/RenameParameterRector.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Nextcloud\Rector\Rector;
 
+use InvalidArgumentException;
 use Nextcloud\Rector\ValueObject\RenameParameter;
 use PhpParser\Node;
 use PhpParser\Node\Expr;
@@ -25,7 +26,6 @@ use Rector\Reflection\ReflectionResolver;
 use Rector\ValueObject\MethodName;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
-use Webmozart\Assert\Assert;
 
 use function count;
 use function is_array;
@@ -60,7 +60,9 @@ class RenameParameterRector extends AbstractRector implements ConfigurableRector
     public function configure(array $configuration): void
     {
         foreach ($configuration as $renameParameter) {
-            Assert::isInstanceOf($renameParameter, RenameParameter::class);
+            if (!$renameParameter instanceof RenameParameter) {
+                throw new InvalidArgumentException('Only supports RenameParameter configurations');
+            }
             $this->renameParameters[] = $renameParameter;
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description

- Webmozart\Assert\Assert only works with a dev checkout
- RectorPrefix202409\Webmozart\Assert\Assert emits a phpstan warning

The `class.prefixed` warning is configured as "nonIgnorable"[^1].

I'm using the same approach now as for `LegacyGetterToOcpServerGetRector` .


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.

[^1]: https://github.com/phpstan/phpstan-src/blob/e8027e7a59ba4e70925c89df51081902aa577e03/src/Rules/ClassForbiddenNameCheck.php#L77-L78