### PR TITLE
feat: Add class to easily import only classnames from Nextcloud namespaces

### DIFF
--- a/src/ClassNameImport/NextcloudNamespaceSkipVoter.php
+++ b/src/ClassNameImport/NextcloudNamespaceSkipVoter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /*
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-only
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace Nextcloud\Rector\ClassNameImport;

--- a/src/ClassNameImport/NextcloudNamespaceSkipVoter.php
+++ b/src/ClassNameImport/NextcloudNamespaceSkipVoter.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace Nextcloud\Rector\ClassNameImport;
+
+use PhpParser\Node;
+use Rector\CodingStyle\Contract\ClassNameImport\ClassNameImportSkipVoterInterface;
+use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
+use Rector\ValueObject\Application\File;
+
+use function in_array;
+use function str_starts_with;
+
+/**
+ * This allows to import only classes from Nextcloud namespaces (OC/OCP/OCA), except for common names (Plugin/Backend/…)
+ *
+ * To use it:
+ * $config = RectorConfig::configure()[…]->withImportNames(importShortClasses:false);
+ * $config->registerService(NextcloudNamespaceSkipVoter::class, tag:ClassNameImportSkipVoterInterface::class);
+ */
+class NextcloudNamespaceSkipVoter implements ClassNameImportSkipVoterInterface
+{
+    /**
+     * @var list<string>
+     */
+    protected array $namespacePrefixes = [
+        'OC',
+        'OCA',
+        'OCP',
+    ];
+    /**
+     * @var list<string>
+     */
+    protected array $skippedClassNames = [
+        'Backend',
+        'Connection',
+        'Exception',
+        'IManager',
+        'IProvider',
+        'Manager',
+        'Plugin',
+        'Provider',
+    ];
+
+    public function shouldSkip(File $file, FullyQualifiedObjectType $fullyQualifiedObjectType, Node $node): bool
+    {
+        if (in_array($fullyQualifiedObjectType->getShortName(), $this->skippedClassNames)) {
+            // Skip common class names to avoid confusion
+            return true;
+        }
+        foreach ($this->namespacePrefixes as $prefix) {
+            if (str_starts_with($fullyQualifiedObjectType->getClassName(), $prefix . '\\')) {
+                // Import Nextcloud namespaces
+                return false;
+            }
+        }
+
+        // Skip everything else
+        return true;
+    }
+}

--- a/tests/ClassNameImport/Fixture/test_fixture.php.inc
+++ b/tests/ClassNameImport/Fixture/test_fixture.php.inc
@@ -1,0 +1,46 @@
+<?php
+
+namespace Nextcloud\Rector\Test\ClassNameImport\Fixture;
+
+use OCP\Authentication\TwoFactorAuth;
+
+class SomeClass
+{
+    public function foo()
+    {
+        $request1 = \OC::$server->get(\OCP\IRequest::class);
+        $request2 = \OCP\Server::get(\OCP\IRequest::class);
+        $class = new \OCA\My\CustomClass();
+        $otherNamespace = new \Rector\Config\RectorConfig();
+        $manager = \OCP\Server::get(\OCP\Share\IManager);
+        $manager = \OCP\Server::get(TwoFactorAuth\IProvider);
+        throw new \Exception('Class from root namespace');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Nextcloud\Rector\Test\ClassNameImport\Fixture;
+
+use OCP\Authentication\TwoFactorAuth;
+use OCP\IRequest;
+use OCP\Server;
+use OCA\My\CustomClass;
+
+class SomeClass
+{
+    public function foo()
+    {
+        $request1 = \OC::$server->get(IRequest::class);
+        $request2 = Server::get(IRequest::class);
+        $class = new CustomClass();
+        $otherNamespace = new \Rector\Config\RectorConfig();
+        $manager = Server::get(\OCP\Share\IManager);
+        $manager = Server::get(TwoFactorAuth\IProvider);
+        throw new \Exception('Class from root namespace');
+    }
+}
+
+?>

--- a/tests/ClassNameImport/Fixture/test_fixture.php.inc
+++ b/tests/ClassNameImport/Fixture/test_fixture.php.inc
@@ -24,10 +24,10 @@ class SomeClass
 
 namespace Nextcloud\Rector\Test\ClassNameImport\Fixture;
 
-use OCP\Authentication\TwoFactorAuth;
 use OCP\IRequest;
 use OCP\Server;
 use OCA\My\CustomClass;
+use OCP\Authentication\TwoFactorAuth;
 
 class SomeClass
 {

--- a/tests/ClassNameImport/NextcloudClassNameImportTest.php
+++ b/tests/ClassNameImport/NextcloudClassNameImportTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Nextcloud\Rector\Test\ClassNameImport;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class NextcloudClassNameImportTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/config.php';
+    }
+}

--- a/tests/ClassNameImport/NextcloudClassNameImportTest.php
+++ b/tests/ClassNameImport/NextcloudClassNameImportTest.php
@@ -21,6 +21,16 @@ final class NextcloudClassNameImportTest extends AbstractRectorTestCase
         $this->doTestFile($filePath);
     }
 
+    /**
+     * @param string[] $configFiles
+     */
+    protected function bootFromConfigFiles(array $configFiles): void
+    {
+        /* Did not find a cleaner way to make sure the registered service is taken into account */
+        self::getContainer()->forgetInstances();
+        parent::bootFromConfigFiles($configFiles);
+    }
+
     public static function provideData(): Iterator
     {
         return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');

--- a/tests/ClassNameImport/config/config.php
+++ b/tests/ClassNameImport/config/config.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Nextcloud\Rector\ClassNameImport\NextcloudNamespaceSkipVoter;
+use Rector\CodingStyle\Contract\ClassNameImport\ClassNameImportSkipVoterInterface;
+use Rector\Config\RectorConfig;
+
+$config = RectorConfig::configure()
+    ->withImportNames(importShortClasses:false);
+
+$config->registerService(NextcloudNamespaceSkipVoter::class, tag:ClassNameImportSkipVoterInterface::class);
+
+return $config;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
This adds a class that can be used by applications wanting to import names, but only from Nextcloud namespaces.
This is what is used in nextcloud/server repository for the apps folder.

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
