### PR TITLE
feat: Replace calls to OC::$server->query with Server::get

### DIFF
--- a/src/Rector/OcServerToOcpServerRector.php
+++ b/src/Rector/OcServerToOcpServerRector.php
@@ -62,7 +62,7 @@ class OcServerToOcpServerRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Change method calls from OC::$server to OCP\Server::get.',
+            'Change method calls from OC::$server->get and OC::$server->query to OCP\Server::get.',
             [
                 new CodeSample(
                     '\OC::$server->get(IAppConfig::class);',

--- a/src/Rector/OcServerToOcpServerRector.php
+++ b/src/Rector/OcServerToOcpServerRector.php
@@ -39,7 +39,7 @@ class OcServerToOcpServerRector extends AbstractRector
         }
 
         if (
-            $methodCallName !== 'get'
+            ($methodCallName !== 'get' && $methodCallName !== 'query')
             || !($node->var instanceof StaticPropertyFetch)
         ) {
             return null;
@@ -62,7 +62,7 @@ class OcServerToOcpServerRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Change method calls from set* to change*.',
+            'Change method calls from OC::$server to OCP\Server::get.',
             [
                 new CodeSample(
                     '\OC::$server->get(IAppConfig::class);',

--- a/tests/Rector/OcServerToOcpServerRector/Fixture/test_fixture.php.inc
+++ b/tests/Rector/OcServerToOcpServerRector/Fixture/test_fixture.php.inc
@@ -12,6 +12,7 @@ class SomeClass
         $request1 = \OC::$server->get(IRequest::class);
         $request2 = \OC::$server->get('\OCP\IRequest');
         $request3 = OC::$server->get(IRequest::class);
+        $request4 = OC::$server->query(IRequest::class);
     }
 }
 
@@ -31,6 +32,7 @@ class SomeClass
         $request1 = \OCP\Server::get(IRequest::class);
         $request2 = \OCP\Server::get('\OCP\IRequest');
         $request3 = \OCP\Server::get(IRequest::class);
+        $request4 = \OCP\Server::get(IRequest::class);
     }
 }
 


### PR DESCRIPTION
## Description
Replace calls to `OC::$server->query` with `OCP\Server::get`
`OC::$server->get` was already handled but not `query`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
