### PR TITLE
chore: Set PHP version in CI to 8.3 to avoid failure

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,7 +33,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@2.31.1"
         with:
-          php-version: "latest"
+          php-version: "8.3"
           coverage: "none"
 
       - name: "Install dependencies (Composer)"
@@ -56,7 +56,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@2.31.1"
         with:
-          php-version: "latest"
+          php-version: "8.3"
           coverage: "none"
           ini-values: "memory_limit=-1"
 
@@ -87,7 +87,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@2.31.1"
         with:
-          php-version: "latest"
+          php-version: "8.3"
           coverage: "none"
 
       - name: "Install dependencies (Composer)"
@@ -113,7 +113,7 @@ jobs:
       - name: "Install PHP"
         uses: "shivammathur/setup-php@2.31.1"
         with:
-          php-version: "latest"
+          php-version: "8.3"
           coverage: "pcov"
           ini-values: "memory_limit=-1"
 


### PR DESCRIPTION
## Description
Set PHP version in CI to 8.3 to avoid failure
When ramsey/devtools supports 8.4 we can go back to latest or bump to 8.4

## Motivation and context

- See https://github.com/nextcloud-libraries/rector/pull/33#issuecomment-2625029658
- See https://github.com/ramsey/devtools/issues/23

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
