### PR TITLE
fix: Add empty sets for versions 28-30

### DIFF
--- a/src/Set/NextcloudSets.php
+++ b/src/Set/NextcloudSets.php
@@ -14,4 +14,7 @@ final class NextcloudSets implements SetListInterface
     public const NEXTCLOUD_25 = __DIR__ . '/../../config/nextcloud-25/nextcloud-25-deprecations.php';
     public const NEXTCLOUD_26 = __DIR__ . '/../../config/nextcloud-26/nextcloud-26-deprecations.php';
     public const NEXTCLOUD_27 = __DIR__ . '/../../config/nextcloud-27/nextcloud-27-deprecations.php';
+    public const NEXTCLOUD_28 = self::NEXTCLOUD_27;
+    public const NEXTCLOUD_29 = self::NEXTCLOUD_27;
+    public const NEXTCLOUD_30 = self::NEXTCLOUD_27;
 }


### PR DESCRIPTION
## Description

We have sets for 25, 26 and 27.
But in our documentation we use NEXTCLOUD_30 in our example.
It’s better to have empty sets for versions without rules yet than to have versions missing from the sets.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
