### PR TITLE
feat: Add rules for all annotations replaced by attributes in 27

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^8.1",
         "nextcloud/ocp": ">=27",
-        "rector/rector": "^2.0"
+        "rector/rector": "^2.0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5",

--- a/config/nextcloud-27/nextcloud-27-deprecations.php
+++ b/config/nextcloud-27/nextcloud-27-deprecations.php
@@ -12,9 +12,24 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(
         AnnotationToAttributeRector::class,
         [
+            new AnnotationToAttribute('AnonRateLimit', 'OCP\AppFramework\Http\Attribute\AnonRateLimit'),
+            new AnnotationToAttribute('ARateLimit', 'OCP\AppFramework\Http\Attribute\ARateLimit'),
+            new AnnotationToAttribute(
+                'AuthorizedAdminSetting',
+                'OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting',
+            ),
+            new AnnotationToAttribute('BruteForceProtection', 'OCP\AppFramework\Http\Attribute\BruteForceProtection'),
+            new AnnotationToAttribute('CORS', 'OCP\AppFramework\Http\Attribute\CORS'),
             new AnnotationToAttribute('NoAdminRequired', 'OCP\AppFramework\Http\Attribute\NoAdminRequired'),
-            new AnnotationToAttribute('PublicPage', 'OCP\AppFramework\Http\Attribute\PublicPage'),
             new AnnotationToAttribute('NoCSRFRequired', 'OCP\AppFramework\Http\Attribute\NoCSRFRequired'),
+            new AnnotationToAttribute(
+                'PasswordConfirmationRequired',
+                'OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired',
+            ),
+            new AnnotationToAttribute('PublicPage', 'OCP\AppFramework\Http\Attribute\PublicPage'),
+            new AnnotationToAttribute('StrictCookiesRequired', 'OCP\AppFramework\Http\Attribute\StrictCookiesRequired'),
+            new AnnotationToAttribute('SubAdminRequired', 'OCP\AppFramework\Http\Attribute\SubAdminRequired'),
+            new AnnotationToAttribute('UserRateLimit', 'OCP\AppFramework\Http\Attribute\UserRateLimit'),
         ],
     );
 };

--- a/config/nextcloud-27/nextcloud-27-deprecations.php
+++ b/config/nextcloud-27/nextcloud-27-deprecations.php
@@ -12,13 +12,12 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(
         AnnotationToAttributeRector::class,
         [
-            new AnnotationToAttribute('AnonRateLimit', 'OCP\AppFramework\Http\Attribute\AnonRateLimit'),
-            new AnnotationToAttribute('ARateLimit', 'OCP\AppFramework\Http\Attribute\ARateLimit'),
+            new AnnotationToAttribute('AnonRateThrottle', 'OCP\AppFramework\Http\Attribute\AnonRateLimit',),
             new AnnotationToAttribute(
                 'AuthorizedAdminSetting',
                 'OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting',
             ),
-            new AnnotationToAttribute('BruteForceProtection', 'OCP\AppFramework\Http\Attribute\BruteForceProtection'),
+            new AnnotationToAttribute('BruteForceProtection', 'OCP\AppFramework\Http\Attribute\BruteForceProtection',),
             new AnnotationToAttribute('CORS', 'OCP\AppFramework\Http\Attribute\CORS'),
             new AnnotationToAttribute('NoAdminRequired', 'OCP\AppFramework\Http\Attribute\NoAdminRequired'),
             new AnnotationToAttribute('NoCSRFRequired', 'OCP\AppFramework\Http\Attribute\NoCSRFRequired'),
@@ -29,7 +28,7 @@ return static function (RectorConfig $rectorConfig): void {
             new AnnotationToAttribute('PublicPage', 'OCP\AppFramework\Http\Attribute\PublicPage'),
             new AnnotationToAttribute('StrictCookiesRequired', 'OCP\AppFramework\Http\Attribute\StrictCookiesRequired'),
             new AnnotationToAttribute('SubAdminRequired', 'OCP\AppFramework\Http\Attribute\SubAdminRequired'),
-            new AnnotationToAttribute('UserRateLimit', 'OCP\AppFramework\Http\Attribute\UserRateLimit'),
+            new AnnotationToAttribute('UserRateThrottle', 'OCP\AppFramework\Http\Attribute\UserRateLimit'),
         ],
     );
 };

--- a/config/nextcloud-27/nextcloud-27-deprecations.php
+++ b/config/nextcloud-27/nextcloud-27-deprecations.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
+use Nextcloud\Rector\Rector\AnnotationToAttributeRector;
 use Nextcloud\Rector\Set\NextcloudSets;
 use Rector\Config\RectorConfig;
-use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Php80\ValueObject\AnnotationToAttribute;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -12,12 +12,13 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(
         AnnotationToAttributeRector::class,
         [
-            new AnnotationToAttribute('AnonRateThrottle', 'OCP\AppFramework\Http\Attribute\AnonRateLimit',),
-            new AnnotationToAttribute(
-                'AuthorizedAdminSetting',
-                'OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting',
-            ),
-            new AnnotationToAttribute('BruteForceProtection', 'OCP\AppFramework\Http\Attribute\BruteForceProtection',),
+            new AnnotationToAttribute('AnonRateThrottle', 'OCP\AppFramework\Http\Attribute\AnonRateLimit'),
+            // This one is commented out because the parameter would need to be transformed into several attributes
+            // new AnnotationToAttribute(
+            //     'AuthorizedAdminSetting',
+            //     'OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting',
+            // ),
+            new AnnotationToAttribute('BruteForceProtection', 'OCP\AppFramework\Http\Attribute\BruteForceProtection'),
             new AnnotationToAttribute('CORS', 'OCP\AppFramework\Http\Attribute\CORS'),
             new AnnotationToAttribute('NoAdminRequired', 'OCP\AppFramework\Http\Attribute\NoAdminRequired'),
             new AnnotationToAttribute('NoCSRFRequired', 'OCP\AppFramework\Http\Attribute\NoCSRFRequired'),

--- a/src/Rector/AnnotationToAttributeRector.php
+++ b/src/Rector/AnnotationToAttributeRector.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace Nextcloud\Rector\Rector;
+
+use PHPStan\PhpDocParser\Ast\Node as DocNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTextNode;
+use PHPStan\Reflection\ReflectionProvider;
+use PhpParser\Node;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Interface_;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\Use_;
+use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
+use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
+use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
+use Rector\Comments\NodeDocBlock\DocBlockUpdater;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Exception\Configuration\InvalidConfigurationException;
+use Rector\Naming\Naming\UseImportsResolver;
+use Rector\Php80\NodeAnalyzer\PhpAttributeAnalyzer;
+use Rector\Php80\NodeFactory\AttrGroupsFactory;
+use Rector\Php80\NodeManipulator\AttributeGroupNamedArgumentManipulator;
+use Rector\Php80\Rector\Class_\AttributeValueResolver;
+use Rector\Php80\ValueObject\AnnotationToAttribute;
+use Rector\Php80\ValueObject\AttributeValueAndDocComment;
+use Rector\Php80\ValueObject\DoctrineTagAndAnnotationToAttribute;
+use Rector\PhpAttribute\NodeFactory\PhpAttributeGroupFactory;
+use Rector\PhpDocParser\PhpDocParser\PhpDocNodeTraverser;
+use Rector\Rector\AbstractRector;
+use Rector\ValueObject\PhpVersionFeature;
+use Rector\VersionBonding\Contract\MinPhpVersionInterface;
+use RectorPrefix202503\Webmozart\Assert\Assert;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+use function array_merge;
+use function sprintf;
+use function strpos;
+use function strtolower;
+use function trim;
+
+final class AnnotationToAttributeRector extends AbstractRector implements
+    ConfigurableRectorInterface,
+    MinPhpVersionInterface
+{
+    /**
+     * @var AnnotationToAttribute[]
+     */
+    private array $annotationsToAttributes = [];
+
+    public function __construct(
+        private PhpAttributeGroupFactory $phpAttributeGroupFactory,
+        private AttrGroupsFactory $attrGroupsFactory,
+        private PhpDocTagRemover $phpDocTagRemover,
+        private AttributeGroupNamedArgumentManipulator $attributeGroupNamedArgumentManipulator,
+        private UseImportsResolver $useImportsResolver,
+        private PhpAttributeAnalyzer $phpAttributeAnalyzer,
+        private DocBlockUpdater $docBlockUpdater,
+        private PhpDocInfoFactory $phpDocInfoFactory,
+        private ReflectionProvider $reflectionProvider,
+        private AttributeValueResolver $attributeValueResolver,
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change classless annotation to attribute', [new ConfiguredCodeSample(<<<'CODE_SAMPLE'
+
+class Example
+{
+    /**
+     * @OldName("/path", name="action")
+     */
+    public function action()
+    {
+    }
+}
+CODE_SAMPLE
+, <<<'CODE_SAMPLE'
+use Name\Space\NewName;
+
+class Example
+{
+    #[NewName(path: '/path', name: 'action')]
+    public function action()
+    {
+    }
+}
+CODE_SAMPLE
+, [new AnnotationToAttribute('OldName', 'Name\Space\NewName')]),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [
+            Class_::class, Property::class, Param::class, ClassMethod::class,
+            Function_::class, Closure::class, ArrowFunction::class, Interface_::class,
+        ];
+    }
+
+    /**
+     * @param Class_|Property|Param|ClassMethod|Function_|Closure|ArrowFunction|Interface_ $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($this->annotationsToAttributes === []) {
+            throw new InvalidConfigurationException(sprintf('The "%s" rule requires configuration.', self::class));
+        }
+        $phpDocInfo = $this->phpDocInfoFactory->createFromNode($node);
+        if (!$phpDocInfo instanceof PhpDocInfo) {
+            return null;
+        }
+        $uses = $this->useImportsResolver->resolveBareUses();
+        // 1. Doctrine annotation classes
+        $annotationAttributeGroups = $this->processDoctrineAnnotationClasses($phpDocInfo, $uses);
+        // 2. bare tags without annotation class, e.g. "@require"
+        $genericAttributeGroups = $this->processGenericTags($phpDocInfo);
+        $attributeGroups = array_merge($annotationAttributeGroups, $genericAttributeGroups);
+        if ($attributeGroups === []) {
+            return null;
+        }
+        // 3. Reprint docblock
+        $this->docBlockUpdater->updateRefactoredNodeWithPhpDocInfo($node);
+        $this->attributeGroupNamedArgumentManipulator->decorate($attributeGroups);
+        $node->attrGroups = array_merge($node->attrGroups, $attributeGroups);
+
+        return $node;
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, AnnotationToAttribute::class);
+        $this->annotationsToAttributes = $configuration;
+    }
+
+    public function provideMinPhpVersion(): int
+    {
+        return PhpVersionFeature::ATTRIBUTES;
+    }
+
+    /**
+     * @return AttributeGroup[]
+     */
+    private function processGenericTags(PhpDocInfo $phpDocInfo): array
+    {
+        $attributeGroups = [];
+        $phpDocNodeTraverser = new PhpDocNodeTraverser();
+        $phpDocNodeTraverser->traverseWithCallable(
+            $phpDocInfo->getPhpDocNode(),
+            '',
+            function (DocNode $docNode) use (&$attributeGroups) {
+                if (!$docNode instanceof PhpDocTagNode) {
+                    return null;
+                }
+                if (
+                    !$docNode->value instanceof GenericTagValueNode
+                    && !$docNode->value instanceof DoctrineAnnotationTagValueNode
+                ) {
+                    return null;
+                }
+                $tag = trim($docNode->name, '@');
+                // not a basic one
+                if (strpos($tag, '\\') !== \false) {
+                    return null;
+                }
+                foreach ($this->annotationsToAttributes as $annotationToAttribute) {
+                    $desiredTag = $annotationToAttribute->getTag();
+                    if (strtolower($desiredTag) !== strtolower($tag)) {
+                        continue;
+                    }
+                    // make sure the attribute class really exists to avoid error on early upgrade
+                    if (!$this->reflectionProvider->hasClass($annotationToAttribute->getAttributeClass())) {
+                        continue;
+                    }
+                    $attributeValueAndDocComment = $this->attributeValueResolver->resolve(
+                        $annotationToAttribute,
+                        $docNode,
+                    );
+                    $attributeGroups[] = $this->phpAttributeGroupFactory->createFromSimpleTag(
+                        $annotationToAttribute,
+                        $attributeValueAndDocComment instanceof AttributeValueAndDocComment ?
+                            $attributeValueAndDocComment->attributeValue : null,
+                    );
+                    // keep partial original comment, if useful
+                    if (
+                        $attributeValueAndDocComment instanceof AttributeValueAndDocComment
+                        && $attributeValueAndDocComment->docComment
+                    ) {
+                        return new PhpDocTextNode($attributeValueAndDocComment->docComment);
+                    }
+
+                    return PhpDocNodeTraverser::NODE_REMOVE;
+                }
+
+                return null;
+            },
+        );
+
+        return $attributeGroups;
+    }
+
+    /**
+     * @param Use_[] $uses
+     *
+     * @return AttributeGroup[]
+     */
+    private function processDoctrineAnnotationClasses(PhpDocInfo $phpDocInfo, array $uses): array
+    {
+        if ($phpDocInfo->getPhpDocNode()->children === []) {
+            return [];
+        }
+        $doctrineTagAndAnnotationToAttributes = [];
+        $doctrineTagValueNodes = [];
+        foreach ($phpDocInfo->getPhpDocNode()->children as $phpDocChildNode) {
+            if (!$phpDocChildNode instanceof PhpDocTagNode) {
+                continue;
+            }
+            if (!$phpDocChildNode->value instanceof DoctrineAnnotationTagValueNode) {
+                continue;
+            }
+            $doctrineTagValueNode = $phpDocChildNode->value;
+            $annotationToAttribute = $this->matchAnnotationToAttribute($doctrineTagValueNode);
+            if (!$annotationToAttribute instanceof AnnotationToAttribute) {
+                continue;
+            }
+            // make sure the attribute class really exists to avoid error on early upgrade
+            if (!$this->reflectionProvider->hasClass($annotationToAttribute->getAttributeClass())) {
+                continue;
+            }
+            $doctrineTagAndAnnotationToAttributes[] = new DoctrineTagAndAnnotationToAttribute(
+                $doctrineTagValueNode,
+                $annotationToAttribute,
+            );
+            $doctrineTagValueNodes[] = $doctrineTagValueNode;
+        }
+        $attributeGroups = $this->attrGroupsFactory->create($doctrineTagAndAnnotationToAttributes, $uses);
+        if ($this->phpAttributeAnalyzer->hasRemoveArrayState($attributeGroups)) {
+            return [];
+        }
+        foreach ($doctrineTagValueNodes as $doctrineTagValueNode) {
+            $this->phpDocTagRemover->removeTagValueFromNode($phpDocInfo, $doctrineTagValueNode);
+        }
+
+        return $attributeGroups;
+    }
+
+    private function matchAnnotationToAttribute(
+        DoctrineAnnotationTagValueNode $doctrineAnnotationTagValueNode,
+    ): ?AnnotationToAttribute {
+        foreach ($this->annotationsToAttributes as $annotationToAttribute) {
+            if (!$doctrineAnnotationTagValueNode->hasClassName($annotationToAttribute->getTag())) {
+                continue;
+            }
+
+            return $annotationToAttribute;
+        }
+
+        return null;
+    }
+}

--- a/src/Rector/AnnotationToAttributeRector.php
+++ b/src/Rector/AnnotationToAttributeRector.php
@@ -45,9 +45,9 @@ use Rector\PhpDocParser\PhpDocParser\PhpDocNodeTraverser;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\PhpVersionFeature;
 use Rector\VersionBonding\Contract\MinPhpVersionInterface;
-use RectorPrefix202503\Webmozart\Assert\Assert;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
 
 use function array_merge;
 use function sprintf;
@@ -55,6 +55,7 @@ use function strpos;
 use function strtolower;
 use function trim;
 
+/** @psalm-suppress PropertyNotSetInConstructor */
 final class AnnotationToAttributeRector extends AbstractRector implements
     ConfigurableRectorInterface,
     MinPhpVersionInterface
@@ -120,6 +121,8 @@ CODE_SAMPLE
 
     /**
      * @param Class_|Property|Param|ClassMethod|Function_|Closure|ArrowFunction|Interface_ $node
+     *
+     * @psalm-suppress MoreSpecificImplementedParamType
      */
     public function refactor(Node $node): ?Node
     {
@@ -148,7 +151,9 @@ CODE_SAMPLE
     }
 
     /**
-     * @param mixed[] $configuration
+     * @param array<object> $configuration
+     *
+     * @psalm-suppress MoreSpecificImplementedParamType
      */
     public function configure(array $configuration): void
     {
@@ -156,6 +161,9 @@ CODE_SAMPLE
         $this->annotationsToAttributes = $configuration;
     }
 
+    /**
+     * @return PhpVersionFeature::ATTRIBUTES
+     */
     public function provideMinPhpVersion(): int
     {
         return PhpVersionFeature::ATTRIBUTES;

--- a/tests/Set/Nextcloud27/Fixture/controller_use_session_annotation.php.inc
+++ b/tests/Set/Nextcloud27/Fixture/controller_use_session_annotation.php.inc
@@ -7,7 +7,6 @@ class SomeController
     /**
      * @AnonRateThrottle(limit=10, period=100)
      * @UserRateThrottle(limit=20, period=200)
-     * @AuthorizedAdminSetting(settings=OCA\NotesTutorial\Settings\NotesAdmin;OCA\NotesTutorial\Settings\NotesSubAdmin)
      * @BruteForceProtection(action=login)
      * @CORS
      * @NoAdminRequired
@@ -31,8 +30,6 @@ class SomeController
 {
     #[\OCP\AppFramework\Http\Attribute\AnonRateLimit(limit: 10, period: 100)]
     #[\OCP\AppFramework\Http\Attribute\UserRateLimit(limit: 20, period: 200)]
-    #[\OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting(settings: 'OCA\NotesTutorial\Settings\NotesAdmin')]
-    #[\OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting(settings: 'OCA\NotesTutorial\Settings\NotesSubAdmin')]
     #[\OCP\AppFramework\Http\Attribute\BruteForceProtection(action: 'login')]
     #[\OCP\AppFramework\Http\Attribute\CORS]
     #[\OCP\AppFramework\Http\Attribute\NoAdminRequired]

--- a/tests/Set/Nextcloud27/Fixture/controller_use_session_annotation.php.inc
+++ b/tests/Set/Nextcloud27/Fixture/controller_use_session_annotation.php.inc
@@ -5,9 +5,18 @@ namespace Nextcloud\Rector\Test\Set\Nextcloud27\Fixture;
 class SomeController
 {
     /**
+     * @AnonRateLimit
+     * @ARateLimit
+     * @AuthorizedAdminSetting
+     * @BruteForceProtection
+     * @CORS
      * @NoAdminRequired
-     * @PublicPage
      * @NoCSRFRequired
+     * @PasswordConfirmationRequired
+     * @PublicPage
+     * @StrictCookiesRequired
+     * @SubAdminRequired
+     * @UserRateLimit
      */
     public function foo()
     {}
@@ -21,9 +30,18 @@ namespace Nextcloud\Rector\Test\Set\Nextcloud27\Fixture;
 
 class SomeController
 {
+    #[\OCP\AppFramework\Http\Attribute\AnonRateLimit]
+    #[\OCP\AppFramework\Http\Attribute\ARateLimit]
+    #[\OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting]
+    #[\OCP\AppFramework\Http\Attribute\BruteForceProtection]
+    #[\OCP\AppFramework\Http\Attribute\CORS]
     #[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
-    #[\OCP\AppFramework\Http\Attribute\PublicPage]
     #[\OCP\AppFramework\Http\Attribute\NoCSRFRequired]
+    #[\OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired]
+    #[\OCP\AppFramework\Http\Attribute\PublicPage]
+    #[\OCP\AppFramework\Http\Attribute\StrictCookiesRequired]
+    #[\OCP\AppFramework\Http\Attribute\SubAdminRequired]
+    #[\OCP\AppFramework\Http\Attribute\UserRateLimit]
     public function foo()
     {}
 }

--- a/tests/Set/Nextcloud27/Fixture/controller_use_session_annotation.php.inc
+++ b/tests/Set/Nextcloud27/Fixture/controller_use_session_annotation.php.inc
@@ -5,10 +5,10 @@ namespace Nextcloud\Rector\Test\Set\Nextcloud27\Fixture;
 class SomeController
 {
     /**
-     * @AnonRateLimit
-     * @ARateLimit
-     * @AuthorizedAdminSetting
-     * @BruteForceProtection
+     * @AnonRateThrottle(limit=10, period=100)
+     * @UserRateThrottle(limit=20, period=200)
+     * @AuthorizedAdminSetting(settings=OCA\NotesTutorial\Settings\NotesAdmin;OCA\NotesTutorial\Settings\NotesSubAdmin)
+     * @BruteForceProtection(action=login)
      * @CORS
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -16,7 +16,6 @@ class SomeController
      * @PublicPage
      * @StrictCookiesRequired
      * @SubAdminRequired
-     * @UserRateLimit
      */
     public function foo()
     {}
@@ -30,10 +29,11 @@ namespace Nextcloud\Rector\Test\Set\Nextcloud27\Fixture;
 
 class SomeController
 {
-    #[\OCP\AppFramework\Http\Attribute\AnonRateLimit]
-    #[\OCP\AppFramework\Http\Attribute\ARateLimit]
-    #[\OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting]
-    #[\OCP\AppFramework\Http\Attribute\BruteForceProtection]
+    #[\OCP\AppFramework\Http\Attribute\AnonRateLimit(limit: 10, period: 100)]
+    #[\OCP\AppFramework\Http\Attribute\UserRateLimit(limit: 20, period: 200)]
+    #[\OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting(settings: 'OCA\NotesTutorial\Settings\NotesAdmin')]
+    #[\OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting(settings: 'OCA\NotesTutorial\Settings\NotesSubAdmin')]
+    #[\OCP\AppFramework\Http\Attribute\BruteForceProtection(action: 'login')]
     #[\OCP\AppFramework\Http\Attribute\CORS]
     #[\OCP\AppFramework\Http\Attribute\NoAdminRequired]
     #[\OCP\AppFramework\Http\Attribute\NoCSRFRequired]
@@ -41,7 +41,6 @@ class SomeController
     #[\OCP\AppFramework\Http\Attribute\PublicPage]
     #[\OCP\AppFramework\Http\Attribute\StrictCookiesRequired]
     #[\OCP\AppFramework\Http\Attribute\SubAdminRequired]
-    #[\OCP\AppFramework\Http\Attribute\UserRateLimit]
     public function foo()
     {}
 }


### PR DESCRIPTION
Fix #17 

## Description

Add rules in 27 set to migrate all annotations to attributes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
