### PR TITLE
Improve legacy oc getter migration

### DIFF
--- a/config/nextcloud-25/nextcloud-25-deprecations.php
+++ b/config/nextcloud-25/nextcloud-25-deprecations.php
@@ -173,7 +173,7 @@ return static function (RectorConfig $rectorConfig): void {
             // Deprecated since 20.0.0
             new LegacyGetterToOcpServerGet('getSettingsManager', 'OCP\Settings\IManager'),
             // Deprecated since 20.0.0 Use 'get(\OCP\Files\AppData\IAppDataFactory')->get($app) instead
-            new LegacyGetterToOcpServerGet('getAppDataDir', 'OCP\Files\IAppData'),
+            new LegacyGetterToOcpServerGet('getAppDataDir', 'OCP\Files\AppData\IAppDataFactory', 'get'),
             // Deprecated since 20.0.0
             new LegacyGetterToOcpServerGet('getLockdownManager', 'OCP\Lockdown\ILockdownManager'),
             // Deprecated since 20.0.0

--- a/src/Rector/LegacyGetterToOcpServerGetRector.php
+++ b/src/Rector/LegacyGetterToOcpServerGetRector.php
@@ -56,17 +56,17 @@ CODE_SAMPLE
         if (!($node instanceof MethodCall)) {
             return null;
         }
+        if (!$node->var instanceof StaticPropertyFetch) {
+            return null;
+        }
+        if (!$this->isName($node->var->name, 'server')) {
+            return null;
+        }
+        if (!$this->isObjectType($node->var->class, new ObjectType('OC'))) {
+            return null;
+        }
         foreach ($this->legacyGetterToOcpServerGet as $config) {
-            if (!$node->var instanceof StaticPropertyFetch) {
-                continue;
-            }
-            if (!$this->isName($node->var->name, 'server')) {
-                continue;
-            }
             if (!$this->isName($node->name, $config->getOldMethod())) {
-                continue;
-            }
-            if (!$this->isObjectType($node->var->class, new ObjectType('OC'))) {
                 continue;
             }
 

--- a/src/Rector/LegacyGetterToOcpServerGetRector.php
+++ b/src/Rector/LegacyGetterToOcpServerGetRector.php
@@ -69,12 +69,29 @@ CODE_SAMPLE
             if (!$this->isName($node->name, $config->getOldMethod())) {
                 continue;
             }
+            $factoryMethod = $config->getFactoryMethod();
+            if ($factoryMethod === null) {
+                if ($node->args !== []) {
+                    /* Skip if there are parameters to the call as they would be lost by the migration */
+                    return null;
+                }
 
-            return $this->nodeFactory->createStaticCall(
-                'OCP\Server',
-                'get',
-                [$this->nodeFactory->createClassConstReference($config->getNewClass())],
-            );
+                return $this->nodeFactory->createStaticCall(
+                    'OCP\Server',
+                    'get',
+                    [$this->nodeFactory->createClassConstReference($config->getNewClass())],
+                );
+            } else {
+                return $this->nodeFactory->createMethodCall(
+                    $this->nodeFactory->createStaticCall(
+                        'OCP\Server',
+                        'get',
+                        [$this->nodeFactory->createClassConstReference($config->getNewClass())],
+                    ),
+                    $factoryMethod,
+                    $node->args,
+                );
+            }
         }
 
         return null;

--- a/src/Rector/OcServerToOcpServerRector.php
+++ b/src/Rector/OcServerToOcpServerRector.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Nextcloud\Rector\Rector;
 
+use PHPStan\Type\ObjectType;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
@@ -33,22 +34,19 @@ class OcServerToOcpServerRector extends AbstractRector
         if (!($node instanceof MethodCall)) {
             return null;
         }
-        $methodCallName = $this->getName($node->name);
-        if ($methodCallName === null) {
+        if (!$node->var instanceof StaticPropertyFetch) {
+            return null;
+        }
+        if (!$this->isName($node->var->name, 'server')) {
             return null;
         }
 
-        if (
-            ($methodCallName !== 'get' && $methodCallName !== 'query')
-            || !($node->var instanceof StaticPropertyFetch)
-        ) {
+        $methodCallName = $this->getName($node->name);
+        if ($methodCallName !== 'get' && $methodCallName !== 'query') {
             return null;
         }
-        $class = $node->var->class;
-        if (
-            !($class instanceof FullyQualified)
-            || $class->getParts() !== ['OC']
-        ) {
+
+        if (!$this->isObjectType($node->var->class, new ObjectType('OC'))) {
             return null;
         }
 

--- a/src/ValueObject/LegacyGetterToOcpServerGet.php
+++ b/src/ValueObject/LegacyGetterToOcpServerGet.php
@@ -16,6 +16,7 @@ final class LegacyGetterToOcpServerGet
     public function __construct(
         private string $oldMethod,
         private string $newClass,
+        private ?string $factoryMethod = null,
     ) {
         RectorAssert::className($oldMethod);
         RectorAssert::className($newClass);
@@ -29,5 +30,10 @@ final class LegacyGetterToOcpServerGet
     public function getNewClass(): string
     {
         return $this->newClass;
+    }
+
+    public function getFactoryMethod(): ?string
+    {
+        return $this->factoryMethod;
     }
 }

--- a/tests/Set/Fixture/test_fixture.php.inc
+++ b/tests/Set/Fixture/test_fixture.php.inc
@@ -16,6 +16,7 @@ class SomeClass
         $request4 = OC::$server->getRequest();
         $request5 = \OC::$server->getRequest();
         $contactManager = \OC::$server->getContactsManager();
+        $deckAppDirectory = \OC::$server->getAppDataDir('deck');
     }
 }
 
@@ -39,6 +40,7 @@ class SomeClass
         $request4 = \OCP\Server::get(\OCP\IRequest::class);
         $request5 = \OCP\Server::get(\OCP\IRequest::class);
         $contactManager = \OCP\Server::get(\OCP\Contacts\IManager::class);
+        $deckAppDirectory = \OCP\Server::get(\OCP\Files\AppData\IAppDataFactory::class)->get('deck');
     }
 }
 

--- a/tests/Set/config/config.php
+++ b/tests/Set/config/config.php
@@ -7,5 +7,5 @@ use Rector\Config\RectorConfig;
 
 return RectorConfig::configure()
     ->withSets([
-        NextcloudSets::NEXTCLOUD_26,
+        NextcloudSets::NEXTCLOUD_25,
     ]);


### PR DESCRIPTION
## Description

```php
            // Deprecated since 20.0.0 Use 'get(\OCP\Files\AppData\IAppDataFactory')->get($app) instead
            new LegacyGetterToOcpServerGet('getAppDataDir', 'OCP\Files\IAppData'),
```

This was wrong, the rector configuration did not match the comment.
Improved code logic, added support for factory method, configure the rector to use it and added a test for it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
