### PR TITLE
Enh/update rector to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
         }
     ],
     "require": {
-        "php": "^8.1"
+        "php": "^8.1",
+        "rector/rector": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5",
-        "ramsey/devtools": "^2.0",
-        "rector/rector": "^1.2"
+        "ramsey/devtools": "^2.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "nextcloud/ocp": "*",
+        "nextcloud/ocp": ">=27",
         "rector/rector": "^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     ],
     "require": {
         "php": "^8.1",
+        "nextcloud/ocp": "*",
         "rector/rector": "^2.0"
     },
     "require-dev": {
@@ -26,7 +27,8 @@
     "prefer-stable": true,
     "autoload": {
         "psr-4": {
-            "Nextcloud\\Rector\\": "src/"
+            "Nextcloud\\Rector\\": "src/",
+            "OCP\\": "vendor/nextcloud/ocp/OCP"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
             "ramsey/composer-repl": true,
             "ramsey/devtools": true
         },
+        "platform": {
+            "php": "8.1"
+        },
         "sort-packages": true
     },
     "extra": {

--- a/src/Set/NextcloudSets.php
+++ b/src/Set/NextcloudSets.php
@@ -4,12 +4,7 @@ declare(strict_types=1);
 
 namespace Nextcloud\Rector\Set;
 
-use Rector\Set\Contract\SetListInterface;
-
-/**
- * @psalm-suppress DeprecatedInterface
- */
-final class NextcloudSets implements SetListInterface
+final class NextcloudSets
 {
     public const NEXTCLOUD_25 = __DIR__ . '/../../config/nextcloud-25/nextcloud-25-deprecations.php';
     public const NEXTCLOUD_26 = __DIR__ . '/../../config/nextcloud-26/nextcloud-26-deprecations.php';

--- a/tests/Rector/LegacyGetterToOcpServerGetRector/config/config.php
+++ b/tests/Rector/LegacyGetterToOcpServerGetRector/config/config.php
@@ -11,7 +11,6 @@ return RectorConfig::configure()
     ->withConfiguredRule(
         LegacyGetterToOcpServerGetRector::class,
         [
-            /** @phpstan-ignore class.notFound */
             new LegacyGetterToOcpServerGet('getRequest', IRequest::class),
             new LegacyGetterToOcpServerGet('getContactsManager', 'OCP\Contacts\IManager'),
         ],


### PR DESCRIPTION
Fix #34 

Not sure about all the changes, I had to pull OCP so that rector finds the classes.
I had to delete my composer.lock and start from scratch, and I set platform php to 8.1 to avoid composer pulling a psalm too recent (otherwise it only runs on latest PHP).