### PR TITLE
fix(rector): handle that reflection might not find controllers

### DIFF
--- a/src/Rector/RenameParameterRector.php
+++ b/src/Rector/RenameParameterRector.php
@@ -29,6 +29,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 use function count;
 use function is_array;
+use function str_contains;
 
 /** @psalm-suppress PropertyNotSetInConstructor */
 class RenameParameterRector extends AbstractRector implements ConfigurableRectorInterface
@@ -81,15 +82,36 @@ class RenameParameterRector extends AbstractRector implements ConfigurableRector
             return null;
         }
 
+        // Get the class name - can be a string or Identifier node
+        $className = $node->name instanceof Node
+            ? ($node->name->name ?? '')
+            : ($node->name ?? '');
+
         $classReflection = $this->reflectionResolver->resolveClassReflection($node);
-        if ($classReflection === null) {
-            return null;
+
+        $shouldProcess = false;
+
+        // If reflection succeeds, verify the class is a Controller or Settings
+        if ($classReflection !== null) {
+            $extendsController = $classReflection->is('OCP\AppFramework\Controller');
+            $implementsSettingsInterface = $classReflection->implementsInterface('OCP\Settings\ISettings');
+
+            if ($extendsController || $implementsSettingsInterface) {
+                $shouldProcess = true;
+            }
         }
 
-        $extendsController = $classReflection->is('OCP\AppFramework\Controller');
-        $implementsSettingsInterface = $classReflection->implementsInterface('OCP\Settings\ISettings');
+        // If reflection failed or didn't match, use class name as fallback heuristic
+        // This allows the rule to work when analyzing apps in isolation where
+        // Nextcloud core classes aren't available or don't have parent classes declared
+        if (!$shouldProcess) {
+            // Only process if class name contains 'Controller' or 'Settings'
+            if (str_contains($className, 'Controller') || str_contains($className, 'Settings')) {
+                $shouldProcess = true;
+            }
+        }
 
-        if (!$extendsController && !$implementsSettingsInterface) {
+        if (!$shouldProcess) {
             return null;
         }
 

--- a/tests/Rector/RenameParameterRector/Fixture/test_fixture_app_isolation.php.inc
+++ b/tests/Rector/RenameParameterRector/Fixture/test_fixture_app_isolation.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+// Simulate an app in isolation where Controller class is NOT available
+// (i.e., OCP namespace is not resolved)
+
+namespace Nextcloud\Rector\Test\Rector\RenameParameterRector\Fixture;
+
+class AccountsController
+{
+    private string $currentUserId;
+
+    public function __construct(string $appName, $UserId) {
+        $this->currentUserId = $UserId;
+    }
+}
+
+?>
+-----
+<?php
+
+// Simulate an app in isolation where Controller class is NOT available
+// (i.e., OCP namespace is not resolved)
+
+namespace Nextcloud\Rector\Test\Rector\RenameParameterRector\Fixture;
+
+class AccountsController
+{
+    private string $currentUserId;
+
+    public function __construct(string $appName, $userId) {
+        $this->currentUserId = $userId;
+    }
+}
+
+?>


### PR DESCRIPTION
## Description

Mail still has `UserId` injection. The rector rule didn't work because in app rectors there is no autoloading to load Nextcloud classes. So the reflection of the controller also didn't work.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
