### PR TITLE
fix(iuserconfig): Fix fully qualified namespace

### DIFF
--- a/config/nextcloud-33/nextcloud-33-deprecations.php
+++ b/config/nextcloud-33/nextcloud-33-deprecations.php
@@ -18,7 +18,7 @@ return static function (RectorConfig $rectorConfig): void {
         [
             new ReplaceInjectedMethodCall(
                 'OCP\IConfig',
-                'OCP\IUserConfig',
+                'OCP\Config\IUserConfig',
                 'userConfig',
                 [
                     'getAllUserValues' => 'getAllValues',

--- a/tests/Set/Nextcloud33/Fixture/test_fixture.php.inc
+++ b/tests/Set/Nextcloud33/Fixture/test_fixture.php.inc
@@ -41,7 +41,7 @@ use OCP\IConfig;
 
 class SomeClass
 {
-    public function __construct(private IConfig $config, private \OCP\IUserConfig $userConfig)
+    public function __construct(private IConfig $config, private \OCP\Config\IUserConfig $userConfig)
     {
     }
 

--- a/tests/Set/Nextcloud33/Fixture/test_fixture_double.php.inc
+++ b/tests/Set/Nextcloud33/Fixture/test_fixture_double.php.inc
@@ -8,7 +8,7 @@
 namespace Nextcloud\Rector\Test\Set\Nextcloud33\Fixture;
 
 use OCP\IConfig;
-use OCP\IUserConfig;
+use OCP\Config\IUserConfig;
 
 class SomeClass
 {
@@ -39,7 +39,7 @@ class SomeClass
 namespace Nextcloud\Rector\Test\Set\Nextcloud33\Fixture;
 
 use OCP\IConfig;
-use OCP\IUserConfig;
+use OCP\Config\IUserConfig;
 
 class SomeClass
 {


### PR DESCRIPTION
Noticed while rectoring https://github.com/nextcloud/twofactor_nextcloud_notification to 34+
Can't really explain why it worked when I made the initial PR

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
